### PR TITLE
Added Excerpt and formatting. Appears on index.

### DIFF
--- a/_posts/2013-12-4-meetup-kickoff.md
+++ b/_posts/2013-12-4-meetup-kickoff.md
@@ -3,6 +3,7 @@ layout: post
 title: Norfolk.js meetup kickoff
 tags: javascript, meetup, norfolk
 published: true
+excerpt: The kickoff meetup for the Norfolk.js group will be <br /><a href="http://www.meetup.com/NorfolkJS/events/150763672/">January 20, 2014</a> with beer and pizza sponsored by <a href="http://www.xtuple.com">xTuple</a>.
 ---
 
 <p>The kickoff meetup for the Norfolk.js group will be</p>


### PR DESCRIPTION
Issue Reference: #12

Hopefully I did this right! :) 

Jekyll will use the first block of text until it hits the excerpt_separator as the post.excerpt text. Since our post.excerpt is wrapped in a <p></p> and the post text itself contain these tags, we're getting extras and they are being printed to the screen. My solution was to use the excerpt: override in the YAML Front-matter.

I have tested this locally, but when I initially worked on the fix, I cloned the repo instead of forking it. I don't know my way around Git well enough to figure out how to fix it, so I just copied my changes into a forked copy of the repo and issued a pull request. Please let me know if you run into any issues. Thank you!

Solution: http://jekyllrb.com/docs/posts/
