### PR TITLE
for issue #31, looks like github is now using kramdown and is default in...

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,5 +6,5 @@ source:      .
 destination: ./_site
 plugins:     ./_plugins
 future:      true
-markdown:    maruku
+markdown:    kramdown
 permalink:   date


### PR DESCRIPTION
... jekyll http://bloerg.net/2013/03/07/using-kramdown-instead-of-maruku.html
